### PR TITLE
Remove empty fields

### DIFF
--- a/files.go
+++ b/files.go
@@ -48,7 +48,13 @@ func ProcessInputFiles(lines []string, key KeyType) ContentType {
 				break
 			}
 
-			var fields []string = strings.Split(lines[linenumber], fieldSeparator)
+			var rawFields []string = strings.Split(lines[linenumber], fieldSeparator)
+			var fields []string = []string{}
+			for _, field := range rawFields {
+				if len(field) > 0 {
+					fields = append(fields, field)
+				}
+			}
 			lastContentLine.Lines = append(lastContentLine.Lines, lines[linenumber])
 			lastContentLine.Fields = append(lastContentLine.Fields, fields...)
 		}

--- a/files_test.go
+++ b/files_test.go
@@ -51,6 +51,26 @@ func TestProcessInputFiles2(t *testing.T) {
 	compareContentTypes(got, expected, t)
 }
 
+func TestProcessInputFiles3(t *testing.T) {
+	var input []string = []string{
+		"Line one",
+		" Line two",
+		" Line three",
+		"Line four",
+	}
+	multiline = 2
+	var key KeyType = KeyType{
+		Type: SingleField,
+		Keys: []int{1},
+	}
+	var expected ContentType = ContentType{
+		{Lines: []string{"Line one", " Line two"}, Fields: []string{"Line", "one", "Line", "two"}, CompareLine: "Line"},
+		{Lines: []string{" Line three", "Line four"}, Fields: []string{"Line", "three", "Line", "four"}, CompareLine: "Line"},
+	}
+	var got ContentType = ProcessInputFiles(input, key)
+	compareContentTypes(got, expected, t)
+}
+
 // func TestProcessInputFiles3(t *testing.T) {
 	// var input []string = []string{
 		// "Line 1 a",

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ yet-another-sort interprets the input in 'multilines' which are line groupings o
 	#1692110033
 	yet-another-sort --multiline 2 --key 2,
 
+Note that when the --key option is used, multiple adjacent field-separators are treated as one separator, i.e. empty fields are ignored.
+
 Options:`)
 		flag.PrintDefaults()
 		fmt.Fprintln(flag.CommandLine.Output(), `


### PR DESCRIPTION
Multiple adjacent field separators will `strings.Split()` into empty
substrings. Remove those.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
