### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -10,6 +10,8 @@ jobs:
   snap:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/nicolasbock/yet-another-sort/security/code-scanning/1](https://github.com/nicolasbock/yet-another-sort/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block to the workflow to limit the GITHUB_TOKEN privileges. As a minimal best practice, it is recommended to set `contents: read`, which grants only read access to repository contents. You can add this block at the root level of the workflow file (after the `name:` line and before `on:`), so it applies to all jobs in the workflow unless a job specifies its own more permissive block. No other changes to logic or existing steps are necessary. You should only edit `.github/workflows/snap.yaml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
